### PR TITLE
Updated Mamba install command to exclude specific versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ conda update -y conda
 
 #### Install Mamba
 ```bash
-conda install -y mamba=0.21.2 -c conda-forge
+conda install -c conda-forge mamba
 ```
 
 ## <a name="install"></a> Installing McClintock


### PR DESCRIPTION
Mamba install command was set to be more general without a specific version