### PR TITLE
Install fixes for Relocate2 and TE-break

### DIFF
--- a/install/Snakefile
+++ b/install/Snakefile
@@ -76,13 +76,19 @@ rule relocate:
        config['paths']['install']+"scripts/relocate.py" 
 
 rule relocate2:
+    params:
+        url = config['URLs']['relocate2'],
+        md5 = config['MD5s']['relocate2'],
+        zipfile = config['paths']['install']+"tools/relocate2/relocate2.zip",
+        log = config['paths']['log_dir']+"install.log",
+
     conda: config['ENVs']['relocate2']
 
     output:
         config['output']['relocate2']
     
-    shell:
-        "echo 'RelocaTE2 env installed' > {output}"
+    script:
+        config['paths']['install']+"scripts/relocate2.py" 
 
 rule ngs_te_mapper:
     params:

--- a/install/Snakefile
+++ b/install/Snakefile
@@ -82,10 +82,10 @@ rule relocate2:
         zipfile = config['paths']['install']+"tools/relocate2/relocate2.zip",
         log = config['paths']['log_dir']+"install.log",
 
-    conda: config['ENVs']['relocate2']
-
     output:
         config['output']['relocate2']
+
+    conda: config['ENVs']['relocate2']
     
     script:
         config['paths']['install']+"scripts/relocate2.py" 

--- a/install/Snakefile
+++ b/install/Snakefile
@@ -80,7 +80,7 @@ rule relocate2:
         url = config['URLs']['relocate2'],
         md5 = config['MD5s']['relocate2'],
         zipfile = config['paths']['install']+"tools/relocate2/relocate2.zip",
-        log = config['paths']['log_dir']+"install.log",
+        log = config['paths']['log_dir']+"install.log"
 
     output:
         config['output']['relocate2']

--- a/install/envs/mcc_relocate2.yml
+++ b/install/envs/mcc_relocate2.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python >= 2.7.12
+  - python = 2.7
   - perl >= 5.10.0
   - samtools = 1.10
   - bowtie2 = 2.2.8
@@ -14,3 +14,4 @@ dependencies:
   - seqtk = 1.2-0
   - pysam = 0.9.0
   - blat = 35
+  - unzip = 6.0

--- a/install/envs/mcc_relocate2.yml
+++ b/install/envs/mcc_relocate2.yml
@@ -5,4 +5,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-    - relocate2=2.0.1=pypl526_4
+  - python >= 2.7.12
+  - perl >= 5.10.0
+  - samtools = 1.10
+  - bowtie2 = 2.2.8
+  - bedtools = 2.26.0-0
+  - bwa = 0.6.2-0
+  - seqtk = 1.2-0
+  - pysam = 0.9.0
+  - blat = 35

--- a/install/envs/mcc_relocate2.yml
+++ b/install/envs/mcc_relocate2.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python = 2.7.12
+  - python >= 2.7.12
   - perl >= 5.10.0
   - samtools = 1.10
   - bowtie2 = 2.2.8

--- a/install/envs/mcc_relocate2.yml
+++ b/install/envs/mcc_relocate2.yml
@@ -5,7 +5,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python >= 2.7.12
+  - python = 2.7.12
   - perl >= 5.10.0
   - samtools = 1.10
   - bowtie2 = 2.2.8

--- a/install/envs/mcc_tebreak.yml
+++ b/install/envs/mcc_tebreak.yml
@@ -19,3 +19,4 @@ dependencies:
   - lockfile=0.12.2
   - ipython_genutils=0.2.0
   - unzip=6.0
+  - numpy>=1.16.5, <1.23.0 

--- a/install/scripts/jitterbug.py
+++ b/install/scripts/jitterbug.py
@@ -4,40 +4,46 @@ sys.path.append(snakemake.config['paths']['mcc_path'])
 import scripts.mccutils as mccutils
 
 def main():
+    #set up installation path and variable names for component method
     install_path = snakemake.config['paths']['install']+"/tools/"
-    raw_name = "jitterbug-b6b3f9c7ee4af042d4410137269f174a1399b752"
-    mod_name = "jitterbug"
 
+    raw_name = "jitterbug-b6b3f9c7ee4af042d4410137269f174a1399b752"
+    method_name = "jitterbug"
+
+    #download component method source code and check for integrity
+    #note: snakemake.params are found in /install/Snakefile
     mccutils.remove(snakemake.params.zipfile)
     download_success = mccutils.download(snakemake.params.url, snakemake.params.zipfile, md5=snakemake.params.md5, max_attempts=3)
 
     if not download_success:
-        print(mod_name+" download failed... exiting...")
+        print(method_name+" download failed... exiting...")
         sys.exit(1)
 
+    #unpack component method source code
     mccutils.remove(snakemake.config['paths']['install']+raw_name)
     command = ["unzip", snakemake.params.zipfile]
     mccutils.run_command(command, log=snakemake.params.log)
 
+    #move component method source code directory into tools directory
     mccutils.remove(install_path+raw_name)
     command = ["mv", snakemake.config['paths']['install']+raw_name, install_path]
     mccutils.run_command(command, log=snakemake.params.log)
 
-    mccutils.remove(install_path+mod_name)
-    mccutils.mkdir(install_path+mod_name)
-
+    #move component method source code files into component method directory
+    mccutils.remove(install_path+method_name)
+    mccutils.mkdir(install_path+method_name)
     for f in os.listdir(install_path+raw_name):
-        command = ["mv", install_path+raw_name+"/"+f, install_path+mod_name]
+        command = ["mv", install_path+raw_name+"/"+f, install_path+method_name]
         mccutils.run_command(command, log=snakemake.params.log)
 
-    command = ["patch", "-i", snakemake.params.patch, install_path+mod_name+"/jitterbug.py"]
+    #patch component method source code files
+    command = ["patch", "-i", snakemake.params.patch, install_path+method_name+"/jitterbug.py"]
     mccutils.run_command(command, log=snakemake.params.log)
     mccutils.remove(install_path+raw_name)
     mccutils.remove(snakemake.params.zipfile)
 
-
-    # write version to file
-    with open(install_path+mod_name+"/version.log","w") as version:
+    #write version to file
+    with open(install_path+method_name+"/version.log","w") as version:
         version.write(snakemake.params.md5)
 
 if __name__ == "__main__":                

--- a/install/scripts/popoolationte.py
+++ b/install/scripts/popoolationte.py
@@ -27,7 +27,7 @@ def main():
     mccutils.remove(install_path+method_name)
     mccutils.mkdir(install_path+method_name)
     for f in os.listdir(snakemake.config['paths']['install']+method_name):
-        command = ["mv", snakemake.config['paths']['install']+method_name+f, install_path+method_name]
+        command = ["mv", snakemake.config['paths']['install']+method_name+"/"+f, install_path+method_name]
         mccutils.run_command(command, log=snakemake.params.log)
 
     #patch component method source code files

--- a/install/scripts/relocate.py
+++ b/install/scripts/relocate.py
@@ -6,7 +6,7 @@ import subprocess
 
 def main():
     #set up installation path and variable names for component method
-    install_path = snakemake.config['paths']['install']+"/tools/"
+    install_path = snakemake.config['paths']['install']+"tools/"
 
     raw_name = "RelocaTE-ce3a2066e15f5c14e2887fdf8dce0485e1750e5b"
     method_name = "relocate"
@@ -55,16 +55,12 @@ def main():
                 with open(install_path+method_name+"/scripts/"+f, "r") as script:
                     for line in script:
                         if "#!/usr/bin/perl" in line:
-                            # line = "#!"+perl_path
                             line = "#!/usr/bin/env perl\n"
                         elif "defined @" in line:
                             line = line.replace("defined @", "@")
-                        
                         elif "$scripts/" in line and "perl" not in line and "relocaTE.pl" in f:
                             line = line.replace("$scripts/", "perl $scripts/")
-                        
                         tmp.write(line)
-            
             mccutils.run_command(["mv", install_path+"tmp", install_path+method_name+"/scripts/"+f])
 
     #write version to file

--- a/install/scripts/relocate2.py
+++ b/install/scripts/relocate2.py
@@ -1,0 +1,64 @@
+import sys
+import os
+sys.path.append(snakemake.config['paths']['mcc_path'])
+import scripts.mccutils as mccutils
+import subprocess
+
+def main():
+    #set up installation path and variable names for component method
+    install_path = snakemake.config['paths']['install']+"tools/"
+
+    raw_name = "RelocaTE2-2.0.1"
+    method_name = "relocate2"
+
+    #download component method source code and check for integrity
+    #note: snakemake.params are found in /install/Snakefile
+    mccutils.remove(snakemake.params.zipfile)
+    download_success = mccutils.download(snakemake.params.url, snakemake.params.zipfile, md5=snakemake.params.md5, max_attempts=3)
+
+    if not download_success:
+        print(method_name+" download failed... exiting...")
+        sys.exit(1)
+
+    #unpack component method source code
+    mccutils.remove(snakemake.config['paths']['install']+raw_name)
+    command = ["unzip", snakemake.params.zipfile]
+    mccutils.run_command(command, log=snakemake.params.log)
+
+    #move component method source code directory into tools directory
+    mccutils.remove(install_path+raw_name)
+    command = ["mv", snakemake.config['paths']['install']+raw_name, install_path]
+    mccutils.run_command(command, log=snakemake.params.log)
+
+    #move component method source code files into component method directory
+    mccutils.remove(install_path+method_name)
+    mccutils.mkdir(install_path+method_name)
+    for f in os.listdir(install_path+raw_name):
+        command = ["mv", install_path+raw_name+"/"+f, install_path+method_name]
+        mccutils.run_command(command, log=snakemake.params.log)
+
+    mccutils.remove(install_path+raw_name)
+    mccutils.remove(snakemake.params.zipfile)
+
+    tools = [ "bwa", "bowtie2", "bowtie2_build", "blat", "samtools", "bedtools", "seqtk" ]
+
+    #update paths to executables in relocate2 config file
+    with open(install_path+method_name"/CONFIG","w") as config_file:
+        config_file.write("#tools\n")
+        for tool in tools:
+            if tool == "bowtie2_build":
+                tool_bin = "bowtie2-build"
+            else:
+                tool_bin = tool
+            output = subprocess.Popen(["which", tool_bin], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            path = output.stdout.read()
+            path = path.decode()
+            line = tool+"="+path
+            config_file.write(line)
+
+    #write version to file
+    with open(install_path+method_name+"/version.log","w") as version:
+        version.write(snakemake.params.md5)
+
+if __name__ == "__main__":                
+    main()

--- a/install/scripts/relocate2.py
+++ b/install/scripts/relocate2.py
@@ -37,13 +37,10 @@ def main():
         command = ["mv", install_path+raw_name+"/"+f, install_path+method_name]
         mccutils.run_command(command, log=snakemake.params.log)
 
-    mccutils.remove(install_path+raw_name)
-    mccutils.remove(snakemake.params.zipfile)
-
     tools = [ "bwa", "bowtie2", "bowtie2_build", "blat", "samtools", "bedtools", "seqtk" ]
 
     #update paths to executables in relocate2 config file
-    with open(install_path+method_name"/CONFIG","w") as config_file:
+    with open(install_path+method_name+"/CONFIG","w") as config_file:
         config_file.write("#tools\n")
         for tool in tools:
             if tool == "bowtie2_build":
@@ -55,6 +52,9 @@ def main():
             path = path.decode()
             line = tool+"="+path
             config_file.write(line)
+
+    mccutils.remove(install_path+raw_name)
+    mccutils.remove(snakemake.params.zipfile)
 
     #write version to file
     with open(install_path+method_name+"/version.log","w") as version:

--- a/internal/install.py
+++ b/internal/install.py
@@ -67,7 +67,7 @@ OUTPUT = {
     "ngs_te_mapper2": INSTALL_PATH+"tools/ngs_te_mapper2/sourceCode/ngs_te_mapper2.py",
     "popoolationte" : INSTALL_PATH+"tools/popoolationte/identify-te-insertsites.pl",
     "popoolationte2" : INSTALL_PATH+"tools/popoolationte2/popte2-v1.10.03.jar",
-    "relocate2" : INSTALL_PATH+"tools/relocate2/relocaTE2.log",
+    "relocate2" : INSTALL_PATH+"tools/relocate2/scripts/relocaTE2.py",
     "tepid" : INSTALL_PATH+"tools/tepid/tepid-map",
     "teflon" : INSTALL_PATH+"tools/teflon/teflon.v0.4.py",
     "jitterbug": INSTALL_PATH+"tools/jitterbug/jitterbug.py",

--- a/scripts/relocaTE2/relocate2_run.py
+++ b/scripts/relocaTE2/relocate2_run.py
@@ -19,6 +19,7 @@ def main():
     median_insert_size_file = snakemake.input.median_insert_size
     log = snakemake.params.log
     status_log = snakemake.params.status_log
+    script_dir = snakemake.params.script_dir
 
     try:
         # ensures intermediate files from previous runs are removed
@@ -55,10 +56,11 @@ def main():
 
 
         median_insert_size = get_median_insert_size(median_insert_size_file)
-        output = subprocess.Popen(["which", "relocaTE2.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        script = output.stdout.read()
-        script = script.decode()
-        script = script.replace("\n","")
+        # output = subprocess.Popen(["which", "relocaTE2.py"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        # script = output.stdout.read()
+        # script = script.decode()
+        # script = script.replace("\n","")
+        script = script_dir+"/relocaTE2.py"
 
 
 

--- a/simulation/envs/mcc_analysis.yml
+++ b/simulation/envs/mcc_analysis.yml
@@ -19,3 +19,4 @@ dependencies:
   - bioconda::bedtools=2.30.0
   - conda-forge::r-ggally
   - bioconda::bcftools
+  - conda-forge::r-upsetr

--- a/snakefiles/relocate2.snakefile
+++ b/snakefiles/relocate2.snakefile
@@ -12,6 +12,7 @@ rule relocaTE2_run:
     conda: config['envs']['relocate2']
 
     params:
+        script_dir = config['args']['mcc_path']+"/install/tools/relocate2/scripts/",
         raw_fq2 = config['in']['fq2'],
         out_dir = config['outdir']['relocate2']+"unfiltered/",
         log = config['args']['log_dir']+"relocaTE2.log",


### PR DESCRIPTION
- updated relocate2 install procedure to use custom .yml file and direct download of Relocate2 source code (bypassing dependency on Relocate2 bioconda recipe)
- constrained numpy version for te-break
- updated readme to include expected results on test data
- updated simulation analysis yml file